### PR TITLE
fix: avoid jsrsasign global-scope initialization in Workers

### DIFF
--- a/vite.substore-transform.js
+++ b/vite.substore-transform.js
@@ -20,6 +20,8 @@ export function subStoreTransformPlugin() {
     let processorsFileSeen = false;
     let openApiDebugPatchApplied = 0;
     let openApiDebugFileSeen = false;
+    let rsPatchApplied = 0;
+    let rsFileSeen = false;
     let subStoreFileSeen = false;
 
     const requiredTargetFiles = [
@@ -28,6 +30,7 @@ export function subStoreTransformPlugin() {
         ['download.js', () => downloadFileSeen, () => downloadPatchApplied],
         ['processors/index.js', () => processorsFileSeen, () => processorsPatchApplied],
         ['core/app.js', () => openApiDebugFileSeen, () => openApiDebugPatchApplied],
+        ['utils/rs.js', () => rsFileSeen, () => rsPatchApplied],
     ];
 
     const dangerousRequireNames = [
@@ -399,6 +402,102 @@ const tasks = {
                         this.error('[sub-store-transform] core/app.js debug 补丁未应用：未命中 OpenAPI 初始化行');
                     }
                 }
+            }
+
+            if (id.includes('sub-store/backend/src/utils/rs.js')) {
+                rsFileSeen = true;
+                contents = `// __SUB_STORE_WORKERS_PATCH__JSRSASIGN_FREE_SHA256_FINGERPRINT__
+function pemToBytes(pem) {
+    const b64 = String(pem || '')
+        .replace(/-----BEGIN[^-]+-----/g, '')
+        .replace(/-----END[^-]+-----/g, '')
+        .replace(/\\s+/g, '');
+    const bin = typeof atob === 'function'
+        ? atob(b64)
+        : globalThis.Buffer.from(b64, 'base64').toString('binary');
+    const bytes = new Array(bin.length);
+    for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i) & 0xff;
+    return bytes;
+}
+
+function rightRotate(value, amount) {
+    return (value >>> amount) | (value << (32 - amount));
+}
+
+function sha256Hex(bytes) {
+    const k = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ];
+    const h = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+        0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ];
+    const msg = bytes.slice();
+    const bitLength = msg.length * 8;
+    msg.push(0x80);
+    while ((msg.length % 64) !== 56) msg.push(0);
+    const high = Math.floor(bitLength / 0x100000000);
+    const low = bitLength >>> 0;
+    msg.push((high >>> 24) & 0xff, (high >>> 16) & 0xff, (high >>> 8) & 0xff, high & 0xff);
+    msg.push((low >>> 24) & 0xff, (low >>> 16) & 0xff, (low >>> 8) & 0xff, low & 0xff);
+
+    const w = new Array(64);
+    for (let offset = 0; offset < msg.length; offset += 64) {
+        for (let i = 0; i < 16; i += 1) {
+            const j = offset + i * 4;
+            w[i] = ((msg[j] << 24) | (msg[j + 1] << 16) | (msg[j + 2] << 8) | msg[j + 3]) >>> 0;
+        }
+        for (let i = 16; i < 64; i += 1) {
+            const s0 = rightRotate(w[i - 15], 7) ^ rightRotate(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+            const s1 = rightRotate(w[i - 2], 17) ^ rightRotate(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+            w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+        }
+        let [a, b, c, d, e, f, g, hh] = h;
+        for (let i = 0; i < 64; i += 1) {
+            const s1 = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25);
+            const ch = (e & f) ^ (~e & g);
+            const temp1 = (hh + s1 + ch + k[i] + w[i]) >>> 0;
+            const s0 = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22);
+            const maj = (a & b) ^ (a & c) ^ (b & c);
+            const temp2 = (s0 + maj) >>> 0;
+            hh = g;
+            g = f;
+            f = e;
+            e = (d + temp1) >>> 0;
+            d = c;
+            c = b;
+            b = a;
+            a = (temp1 + temp2) >>> 0;
+        }
+        h[0] = (h[0] + a) >>> 0;
+        h[1] = (h[1] + b) >>> 0;
+        h[2] = (h[2] + c) >>> 0;
+        h[3] = (h[3] + d) >>> 0;
+        h[4] = (h[4] + e) >>> 0;
+        h[5] = (h[5] + f) >>> 0;
+        h[6] = (h[6] + g) >>> 0;
+        h[7] = (h[7] + hh) >>> 0;
+    }
+    return h.map((n) => n.toString(16).padStart(8, '0')).join('');
+}
+
+export function generateFingerprint(caStr) {
+    const hex = sha256Hex(pemToBytes(caStr));
+    return hex.match(/.{2}/g).join(':').toUpperCase();
+}
+
+export default {
+    generateFingerprint,
+};
+`;
+                rsPatchApplied += 1;
             }
 
             if (contents !== code) {


### PR DESCRIPTION
Hi, I ran into a runtime failure while deploying the current multi-tenant Worker build on Cloudflare Workers.

The deployment itself succeeds, but the user API endpoint fails at runtime:

```text
/<user-path>/api/utils/env -> 500 Internal Server Error
```

After temporarily exposing the caught error body, the root cause was:

```text
Disallowed operation called within global scope. Asynchronous I/O (ex: fetch() or connect()), setting a timeout, and generating random values are not allowed within global scope.
    at requireJsrsasign (...)
```

`Sub-Store` imports `jsrsasign` through `backend/src/utils/rs.js`. In the Worker bundle this is enough to initialize `jsrsasign` at module/global scope, which Cloudflare rejects before the actual API handler can finish initializing.

This patch replaces that small `utils/rs.js` usage during the existing Vite transform step. The upstream file only needs `generateFingerprint(caStr)`, so the transform now emits a small Worker-safe PEM-to-DER + SHA-256 implementation instead of importing the full `jsrsasign` package.

I kept the patch inside `vite.substore-transform.js` so the upstream Sub-Store source remains unchanged and the existing build-time patch validation still catches whether `utils/rs.js` was included in the build graph.

Validation I ran:

- `node --check vite.substore-transform.js`
- Deployed the patched Worker from my fork
- Verified the previously failing endpoint now returns `200`:

```text
/<user-path>/api/utils/env -> 200
backend: Surge
version: 2.22.29
```

This should unblock the current Cloudflare Workers deployment path without pinning Sub-Store to an older version or adding runtime debug output.
