### PR TITLE
fix(build): 适配 Sub-Store 2.24.2 download.js 变更，补丁恢复可用

### DIFF
--- a/vite.substore-transform.js
+++ b/vite.substore-transform.js
@@ -292,7 +292,7 @@ const tasks = {
                     const before = contents.slice(0, startIdx);
                     const chunk = contents.slice(startIdx, endIdx);
                     const after = contents.slice(endIdx);
-                    const requiredNeedles = ['tasks.has(id)', 'tasks.set(id, result)', 'const id = hex_md5('];
+                    const requiredNeedles = ['tasks.has(id)', 'tasks.set(id,', 'const id = hex_md5('];
                     const missing = requiredNeedles.filter((n) => !chunk.includes(n));
                     if (missing.length > 0) {
                         this.error(`[sub-store-transform] download.js 结构已变化，补丁未应用：缺少关键片段: ${missing.join(', ')}`);
@@ -307,6 +307,7 @@ const tasks = {
     awaitCustomCache,
     noCache,
     preprocess,
+    options = {},
 ) {
     let $arguments = {};
     try {
@@ -329,12 +330,19 @@ const tasks = {
     }
 
     if (noCache || ($arguments && $arguments.noCache)) {
-        return await __download_impl__(rawUrl, ua, timeout, customProxy, skipCustomCache, awaitCustomCache, noCache, preprocess);
+        return await __download_impl__(rawUrl, ua, timeout, customProxy, skipCustomCache, awaitCustomCache, noCache, preprocess, options);
+    }
+
+    let optionsKey = '';
+    try {
+        optionsKey = options && typeof options === 'object' ? JSON.stringify(options) : String(options ?? '');
+    } catch (e) {
+        optionsKey = '';
     }
 
     const context = globalThis.__substore_get_active_context__?.();
     const scope = context?.user?.id ?? context?.requestId ?? '';
-    const inflightKey = String(scope) + '::' + String(ua || '') + '::' + String(rawUrl) + '::' + (preprocess ? '1' : '0');
+    const inflightKey = String(scope) + '::' + String(ua || '') + '::' + String(rawUrl) + '::' + (preprocess ? '1' : '0') + '::' + optionsKey;
     if (!globalThis.__sub_store_workers_inflight_tasks__) {
         globalThis.__sub_store_workers_inflight_tasks__ = new Map();
     }
@@ -343,7 +351,7 @@ const tasks = {
     }
     const p = (async () => {
         try {
-            return await __download_impl__(rawUrl, ua, timeout, customProxy, skipCustomCache, awaitCustomCache, noCache, preprocess);
+            return await __download_impl__(rawUrl, ua, timeout, customProxy, skipCustomCache, awaitCustomCache, noCache, preprocess, options);
         } finally {
             globalThis.__sub_store_workers_inflight_tasks__.delete(inflightKey);
         }


### PR DESCRIPTION
- download.js 上游将 tasks.set 的实参从 result 重命名为 rawResult， 结构校验 needle 改为前缀匹配 'tasks.set(id,'，避免误判结构变化
- download() 新增第 9 个参数 options（用于 age 解密密钥）， 补丁 wrapper 同步透传 options 给 __download_impl__，并纳入 inflightKey 去重键，避免不同 options 的请求被错误合并