### PR TITLE
fix(transform): 兼容 Sub-Store 2.36.32+ 手写 Peggy 解析器

### DIFF
--- a/vite.substore-transform.js
+++ b/vite.substore-transform.js
@@ -73,7 +73,12 @@ export function subStoreTransformPlugin() {
     function precompilePeggyParser(contents, id, pluginContext) {
         const match = /const\s+grammars\s*=\s*String\.raw`([\s\S]*?)`;/.exec(contents);
         if (!match) {
-            pluginContext.error(`[sub-store-transform] ${id} Peggy parser 预编译失败：未找到 grammars`);
+            // Sub-Store 2.36.32+ 将 trojan-uri.js 改写为手写解析器（不再内嵌 Peggy grammar），
+            // 这类文件无需预编译，原样放行；只有仍引用 peggy 却找不到 grammar 时才报错。
+            if (/\bpeggy\b/.test(contents)) {
+                pluginContext.error(`[sub-store-transform] ${id} Peggy parser 预编译失败：未找到 grammars`);
+            }
+            return null;
         }
 
         const parserSource = peggy.generate(match[1], {
@@ -138,7 +143,10 @@ export default function getParser() {
             }
 
             if (id.includes('sub-store/backend/src/core/proxy-utils/parsers/peggy/')) {
-                contents = precompilePeggyParser(contents, id, this);
+                const precompiled = precompilePeggyParser(contents, id, this);
+                if (precompiled !== null) {
+                    contents = precompiled;
+                }
             }
 
             if (id.includes('vendor/express.js')) {


### PR DESCRIPTION
## 问题

Sub-Store 2.36.32 将 `backend/src/core/proxy-utils/parsers/peggy/trojan-uri.js` 从内嵌 Peggy grammar（`const grammars = String.raw...`）改写为手写解析器（`parseTrojan` + `getParser()`），导致 `vite build` 在 `sub_store` 环境报错：

```
[sub-store-transform] trojan-uri.js Peggy parser 预编译失败：未找到 grammars
```

## 修复

`precompilePeggyParser` 不再对 peggy 目录下所有文件强制要求匹配 grammar：

- 未找到 grammar 且文件不引用 peggy 时（手写解析器），原样放行，其自带的 `getParser()` 接口与预编译产物一致；
- 仍引用 peggy 却找不到 grammar 时才报错，避免未来上游格式变化被静默吞掉。

## 验证

- 本地复现：拉取 Sub-Store 2.36.32，Node 24 + pnpm 11 下构建报同样错误；
- 修复后 `pnpm run build:workers` 通过：`sub_store` 461 个模块构建成功；
- 产物中 `peggy.generate` 为 0，手写 `parseTrojan` 已正确打包。